### PR TITLE
dc group rapid_release added

### DIFF
--- a/src/ensembl/production/handover/celery_app/utils.py
+++ b/src/ensembl/production/handover/celery_app/utils.py
@@ -213,7 +213,7 @@ def submit_dc(spec, src_url, db_type):
             division_msg = 'division: %s' % get_division(src_uri, tgt_uri, db_type)
             log_and_publish(make_report('DEBUG', division_msg, spec, src_uri))
             log_and_publish(submitting_dc_report)
-            dc_group = 'corelike,rapid_release' if cfg.HANDOVER_TYPE == 'rapid' else : 'corelike'
+            dc_group = 'corelike,rapid_release' if cfg.HANDOVER_TYPE == 'rapid' else  'corelike'
             dc_job_id = dc_client.submit_job(server_url, src_url.database, None, None,
                                              db_type, None, dc_group, 'critical', None, handover_token, staging_uri)
         else:
@@ -222,7 +222,7 @@ def submit_dc(spec, src_url, db_type):
             division_msg = 'division: %s' % get_division(src_uri, tgt_uri, db_type)
             log_and_publish(make_report('DEBUG', division_msg, spec, src_uri))
             log_and_publish(submitting_dc_report)
-            dc_group = db_type + ',rapid_release' if cfg.HANDOVER_TYPE == 'rapid' else : db_type
+            dc_group = db_type + ',rapid_release' if cfg.HANDOVER_TYPE == 'rapid' else  db_type
             dc_job_id = dc_client.submit_job(server_url, src_url.database, None, None,
                                              db_type, None, dc_group, 'critical', None, handover_token, staging_uri)
     except Exception as e:

--- a/src/ensembl/production/handover/celery_app/utils.py
+++ b/src/ensembl/production/handover/celery_app/utils.py
@@ -213,16 +213,18 @@ def submit_dc(spec, src_url, db_type):
             division_msg = 'division: %s' % get_division(src_uri, tgt_uri, db_type)
             log_and_publish(make_report('DEBUG', division_msg, spec, src_uri))
             log_and_publish(submitting_dc_report)
+            dc_group = 'corelike,rapid_release' if cfg.HANDOVER_TYPE == 'rapid' else : 'corelike'
             dc_job_id = dc_client.submit_job(server_url, src_url.database, None, None,
-                                             db_type, None, 'corelike', 'critical', None, handover_token, staging_uri)
+                                             db_type, None, dc_group, 'critical', None, handover_token, staging_uri)
         else:
             db_msg = 'src_uri: %s dbtype %s server_url %s' % (src_uri, db_type, server_url)
             log_and_publish(make_report('DEBUG', db_msg, spec, src_uri))
             division_msg = 'division: %s' % get_division(src_uri, tgt_uri, db_type)
             log_and_publish(make_report('DEBUG', division_msg, spec, src_uri))
             log_and_publish(submitting_dc_report)
+            dc_group = db_type + ',rapid_release' if cfg.HANDOVER_TYPE == 'rapid' else : db_type
             dc_job_id = dc_client.submit_job(server_url, src_url.database, None, None,
-                                             db_type, None, db_type, 'critical', None, handover_token, staging_uri)
+                                             db_type, None, dc_group, 'critical', None, handover_token, staging_uri)
     except Exception as e:
         err_msg = 'Handover failed, Cannot submit dc job'
         log_and_publish(make_report('ERROR', err_msg, spec, src_uri))


### PR DESCRIPTION
Mis-format display name will afftect the new ftp file dumping pipeline used in rapid relase. There is a Datacheck DisplayNameFormat to Find this error. We can add this dc to core group to find out error during initial stage of handover but it will enforce to apply for main site as well which is not mandatory for time being. 

Moreinfo in ticket: https://www.ebi.ac.uk/panda/jira/browse/ENSPROD-7112